### PR TITLE
Make calculator demo responsive on mobile

### DIFF
--- a/docs/demos/calculator.css
+++ b/docs/demos/calculator.css
@@ -1,7 +1,8 @@
 .calculator {
-  width: 400px;
+  width: min(400px, 95vw);
   display: flex;
   flex-wrap: wrap;
+  row-gap: 10px;
   justify-content: space-between;
   position: absolute;
   top: 50%;
@@ -9,8 +10,7 @@
   transform: translate(-50%, -50%);
 }
 .calculator button {
-  width: 125px;
-  margin: 10px 10px 0 0;
+  width: calc((100% - 20px) / 3);
   height: 50px;
   font-size: 2em;
   background-color: var(--gray-l);


### PR DESCRIPTION
Previously the calculator demo had fixed units for the width, making it overflow on mobile. We can fix that by setting the width to 400px or 95vw, whichever is smaller.