### PR TITLE
Bugfix/w should support null values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,9 @@ function isTpl(template: any): template is ArrowTemplate {
 }
 
 function isR(obj: any): obj is ReactiveProxy<DataSource> {
-  return typeof obj === 'object' && typeof obj.$on === 'function'
+  return (
+    typeof obj === 'object' && obj !== null && typeof obj.$on === 'function'
+  )
 }
 
 function has(obj: DataSource, property: DataSourceKey) {
@@ -720,13 +722,13 @@ export function r<T extends DataSource>(
   const children: string[] = []
   const proxySource: ProxyDataSource<T> = isArray ? [] : Object.create(data, {})
   for (const property in data) {
-    if (typeof data[property] === 'object') {
-      proxySource[property] = !isR(data[property])
-        ? r(data[property])
-        : data[property]
+    const entry = data[property]
+    
+    if (typeof entry === 'object' && entry !== null) {
+      proxySource[property] = !isR(entry) ? r(entry) : entry
       children.push(property)
     } else {
-      proxySource[property] = data[property]
+      proxySource[property] = entry
     }
   }
 

--- a/test/w.test.ts
+++ b/test/w.test.ts
@@ -1,0 +1,55 @@
+import { nextTick, r, w } from '../src'
+
+type Data = {
+  value: number | null
+}
+
+describe('w', () => {
+  it('should call when depencency changes', async () => {
+    const d = r({ value: 0 })
+
+    const callback = jest.fn(() => {
+      d.value
+    })
+
+    w(callback)
+
+    await nextTick()
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    d.value = 10
+    await nextTick()
+
+    expect(callback).toHaveBeenCalledTimes(2)
+
+    d.value = 20
+    await nextTick()
+
+    expect(callback).toHaveBeenCalledTimes(3)
+  })
+
+  it('should handle null values', async () => {
+    const d = r<Data>({ value: null })
+
+    const inner = jest.fn()
+
+    function callback() {
+      if (d.value !== null) {
+        inner()
+      }
+    }
+
+    w(callback)
+
+    await nextTick()
+    expect(inner).toHaveBeenCalledTimes(0) // while value is null, inner should not be called
+
+    d.value = 10
+    await nextTick()
+    expect(inner).toHaveBeenCalledTimes(1)
+
+    d.value = null
+    await nextTick()
+    expect(inner).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/w.test.ts
+++ b/test/w.test.ts
@@ -42,7 +42,7 @@ describe('w', () => {
     w(callback)
 
     await nextTick()
-    expect(inner).toHaveBeenCalledTimes(0) // while value is null, inner should not be called
+    expect(inner).toHaveBeenCalledTimes(0) // if value is null, inner should not be called
 
     d.value = 10
     await nextTick()


### PR DESCRIPTION
This PR fixes bug from https://github.com/justin-schroeder/arrow-js/issues/9 

Additional typeguards have been added, for handling null values, alongside test cases for bug reproduction and basic `w` use case

