### PR TITLE
fix issue #36

### DIFF
--- a/test/w.test.ts
+++ b/test/w.test.ts
@@ -52,4 +52,67 @@ describe('w', () => {
     await nextTick()
     expect(inner).toHaveBeenCalledTimes(1)
   })
+
+  it('should handle changes inside a watcher', async () => {
+    const d1 = r<Data>({ value: 0 })
+    const d2 = r<Data>({ value: 1 })
+
+    const cb1 = jest.fn()
+    const cb2 = jest.fn()
+
+    function callback() {
+      if (d1.value === 1) {
+        // triggers other watcher
+        d2.value = 2
+        // triggers itself
+        d1.value = 2
+      } else if (d1.value === 2) {
+        cb1()
+      }
+    }
+    function callback2() {
+      if (d2.value === 2) {
+        cb2()
+      }
+    }
+    w(callback2)
+    w(callback)
+    expect(cb1).toHaveBeenCalledTimes(0)
+    expect(cb2).toHaveBeenCalledTimes(0)
+
+    d1.value = 1
+    await nextTick()
+    expect(cb1).toHaveBeenCalledTimes(0)
+    expect(cb2).toHaveBeenCalledTimes(0)
+
+    await nextTick()
+    expect(cb1).toHaveBeenCalledTimes(1)
+    expect(cb2).toHaveBeenCalledTimes(1)
+    expect(d1.value).toStrictEqual(2)
+    expect(d2.value).toStrictEqual(2)
+  })
+
+  it.only('should handle own changes inside a watcher on initial call', async () => {
+    const d = r<Data>({ value: 1 })
+
+    const cb1 = jest.fn()
+
+    function callback() {
+      if (d.value === 1) {
+        // should trigger itself
+        d.value = 2
+      } else if (d.value === 2) {
+        cb1()
+      }
+    }
+
+    // this only works if we separate the dependency from the callback
+    w(() => d.value, callback)
+
+    expect(cb1).toHaveBeenCalledTimes(0)
+
+    await nextTick()
+    expect(cb1).toHaveBeenCalledTimes(1)
+    expect(d.value).toStrictEqual(2)
+  })
 })


### PR DESCRIPTION
The fix makes sure that callbacks are queued while executing the queue.

See also issue #36

There is still a case which is not working:
If the watch callback is changing a value which should trigger this watch on the initial call it will not be called again because the callback can not be added before the initial call.
I added a test do validate and show the workaround.