### PR TITLE
fix typo: missing double-quote on HTML example

### DIFF
--- a/docs/examples/TemplateExamples.js
+++ b/docs/examples/TemplateExamples.js
@@ -129,7 +129,7 @@ html\`
 </ul>
 
 <form @submit="\${addItem}">
-  <input type="text" id="new-item>
+  <input type="text" id="new-item">
   <button>Add</button>
 </form>\``,
 


### PR DESCRIPTION
I noticed on the website there is this [small typo](https://github.com/justin-schroeder/arrow-js/blob/abcdb75347a9058724cf7f80896b24e4cd41d97d/docs/examples/TemplateExamples.js#L132) on the "Lists" example.

The live demo seems not to be affected by this issue.
