### PR TITLE
WIP: Adds dark mode support to web docs

### DIFF
--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -44,7 +44,7 @@
 
   --c-nav-link-text: var(--black);
   --c-nav-link-text-hover: var(--black);
-  --c-nav-background: var(--white);
+  --c-nav-bg: var(--white);
 
   --c-warning: var(--yellow);
   --c-tip: var(--green);
@@ -71,11 +71,11 @@
   --c-code-text: var(--dark-d);
 
   --color-selection-text: var(--black);
-  --color-selection-background: var(--yellow);
+  --color-selection-bg: var(--yellow);
 }
 
 ::selection {
-  background-color: var(--color-selection-background);
+  background-color: var(--color-selection-bg);
   color: var(--color-selection-text);
 }
 
@@ -435,7 +435,7 @@ aside[data-is-open]::after {
 .navigation {
   position: sticky;
   top: 0;
-  background-color: var(--c-nav-background);
+  background-color: var(--c-nav-bg);
   margin: 0 -1em 2em -1em;
   height: 3.25em;
   z-index: 50;

--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -14,6 +14,15 @@
   --red: #fd335e;
   --purple: #f2efff;
   --purple-d: #9e36ff;
+
+  --white: #ffffff;
+  --black: #000000;
+  --black-soft:#1e1e20;
+
+  --yellow-dimm: rgba(234, 179, 8, .05);
+  --red-dimm: rgba(244, 63, 94, .05);
+  --green-dimm: rgba(16, 185, 129, .05);
+  --purple-dimm: rgba(100, 108, 255, .05);
 }
 
 ::selection {

--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -23,14 +23,17 @@
   --red-dimm: rgba(244, 63, 94, .05);
   --green-dimm: rgba(16, 185, 129, .05);
   --purple-dimm: rgba(100, 108, 255, .05);
-}
 
-:root[theme="light"] {
   --c-primary: var(--yellow);
   --c-neutral: var(--white);
   --c-neutral-inverse: var(--black);
   --c-highlight: var(--yellow);
   --c-mute: var(--dark);
+
+  --nav-inner-shadow-opened: 0 0 1em rgba(0, 0, 0, .1);
+}
+
+:root[theme="light"] {
 
   --c-body-text: var(--dark);
   --c-body-bg: var(--white);
@@ -53,7 +56,6 @@
   --c-nav-inner-bg: var(--white);
   --c-nav-inner-border:var(--gray-l);
   --c-nav-inner-border-top: var(--gray-l);
-  --nav-inner-shadow-opened: 0 0 1em rgba(0, 0, 0, .1);
 
   --c-warning: var(--yellow);
   --c-tip: var(--green);
@@ -83,6 +85,63 @@
 
   --c-selection-text: var(--black);
   --c-selection-bg: var(--yellow);
+}
+
+:root[theme="dark"] {
+  color-scheme: dark;
+
+  --c-body-text: var(--gray-l);
+  --c-body-bg: var(--black-soft);
+  --c-heading-text: var(--gray-ll);
+  --c-subheading-text: var(--gray-l);
+  --c-subheading-highlight: var(--yellow);
+
+  --c-list-item-text: var(--gray-ll);
+  --c-list-item-marker: var(--c-primary);
+  --c-list-item-inner-marker: var(--gray-l);
+
+  --c-link-text: var(--gray-l);
+  --c-link-text-hover: var(--gray-ll);
+  --c-link-social-icon: var(--gray-l);
+
+  --c-nav-link-text: var(--gray-l);
+  --c-nav-link-text-hover: var(--gray-ll);
+  --c-nav-link-text-selected: var(--gray-l);
+  --c-nav-bg: transparent;
+  --c-nav-inner-bg: var(--black-soft);
+  --c-nav-inner-border: var(--dark-d);
+  --c-nav-inner-border-top: var(--gray-l);
+
+
+  --c-warning: var(--yellow);
+  --c-tip: var(--green);
+  --c-tip-accent: var(--green-l);
+  --c-error: var(--red);
+  --c-error-accent: var(--red-l);
+  --c-info: var(--purple-d);
+  --c-info-accent: var(--purple);
+
+  --c-warning-bg: var(--yellow-dimm);
+  --c-error-bg: var(--red-dimm);
+  --c-info-bg: var(--purple-dimm);
+  --c-tip-bg: var(--green-dimm);
+
+  --c-tip-text: var(--green);
+  --c-warning-text: var(--yellow-m);
+  --c-error-text: var(--red);
+  --c-info-text: var(--purple);
+
+  --c-decor-line-bg: var(--dark);
+  --c-border-style: var(--c-neutral-inverse);
+
+  --c-code-bg: var(--dark-d);
+  --c-code-text: var(--gray-l);
+  --c-code-console-text: var(--c-tip);
+  --c-code-console-bg: transparent;
+
+  --c-selection-text: var(--black);
+  --c-selection-bg: var(--yellow);
+
 }
 
 ::selection {

--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -38,13 +38,22 @@
   --c-subheading-text: var(--dark);
   --c-subheading-highlight: var(--yellow);
 
+  --c-list-item-text: var(--black);
+  --c-list-item-marker:var(--c-primary);
+  --c-list-item-inner-marker: var(--dark);
+
   --c-link-text: var(--color-neutral-inverse);
   --c-link-text-hover: var(--dark-d);
   --c-link-social-icon: var(--dark);
 
   --c-nav-link-text: var(--black);
   --c-nav-link-text-hover: var(--black);
-  --c-nav-bg: var(--white);
+  --c-nav-link-text-selected:var(--black);
+  --c-nav-bg: transparent;
+  --c-nav-inner-bg: var(--white);
+  --c-nav-inner-border:var(--gray-l);
+  --c-nav-inner-border-top: var(--gray-l);
+  --nav-inner-shadow-opened: 0 0 1em rgba(0, 0, 0, .1);
 
   --c-warning: var(--yellow);
   --c-tip: var(--green);
@@ -64,11 +73,13 @@
   --c-error-text: var(--dark);
   --c-info-text: var(--dark-d);
 
-  --c-divider: var(--gray-l);
+  --c-decor-line-bg: var(--gray-l);
   --c-border-style: var(--gray-l);
 
   --c-code-bg: var(--gray-ll);
   --c-code-text: var(--dark-d);
+  --c-code-console-text: var(--c-tip);
+  --c-code-console-bg: transparent;
 
   --color-selection-text: var(--black);
   --color-selection-bg: var(--yellow);

--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -28,7 +28,7 @@
 :root[theme="light"] {
   --c-primary: var(--yellow);
   --c-neutral: var(--white);
-  --c-neutral-inv: var(--black);
+  --c-neutral-inverse: var(--black);
   --c-highlight: var(--yellow);
   --c-mute: var(--dark);
 

--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -42,7 +42,7 @@
   --c-list-item-marker:var(--c-primary);
   --c-list-item-inner-marker: var(--dark);
 
-  --c-link-text: var(--color-neutral-inverse);
+  --c-link-text: var(--c-neutral-inverse);
   --c-link-text-hover: var(--dark-d);
   --c-link-social-icon: var(--dark);
 
@@ -81,13 +81,13 @@
   --c-code-console-text: var(--c-tip);
   --c-code-console-bg: transparent;
 
-  --color-selection-text: var(--black);
-  --color-selection-bg: var(--yellow);
+  --c-selection-text: var(--black);
+  --c-selection-bg: var(--yellow);
 }
 
 ::selection {
-  background-color: var(--color-selection-bg);
-  color: var(--color-selection-text);
+  background-color: var(--c-selection-bg);
+  color: var(--c-selection-text);
 }
 
 html {

--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -75,8 +75,8 @@
 }
 
 ::selection {
-  background-color: var(--yellow);
-  color: black;
+  background-color: var(--color-selection-background);
+  color: var(--color-selection-text);
 }
 
 html {
@@ -90,7 +90,8 @@ body {
   line-height: 1.5;
   font-size: 16px;
   -webkit-font-smoothing: antialiased;
-  color: var(--dark);
+  color: var(--c-body-text);
+  background-color: var(--c-body-bg);
 }
 
 .container {
@@ -153,10 +154,10 @@ ul li img {
   line-height: 0;
 }
 .social-links li a {
-  color: var(--gray);
+  color: var(--c-link-social-icon);
 }
 .social-links li a:hover {
-  color: var(--dark-d);
+  color: var(--c-link-text-hover);
 }
 .social-links li,
 .social-links li svg {
@@ -175,17 +176,19 @@ ul li img {
 
 .stage .warning,
 .stage .error {
-  background-color: var(--yellow-l);
+  background-color: var(--c-warning-bg);
+  color:var(--c-warning-text);
   padding: 1em;
   font-size: .875em;
-  border-bottom: 1px solid var(--gray-l);
+  border-bottom: 1px solid var(--c-border-style);
   align-items: center;
   padding-left: 3.25em;
   position: relative;
 }
 
 .stage .error {
-  background-color: var(--red-l);
+  background-color: var(--c-error-bg);
+  color: var(--c-error-text);
 }
 
 .stage .warning img,
@@ -200,7 +203,7 @@ h1,
 h2,
 h3 {
   margin: 0 0 1em 0;
-  color: black;
+  color: var(--c-heading-text);
 }
 h1 {
   font-size: 2.5em;
@@ -212,7 +215,7 @@ h1::after {
   content: '';
   height: 1px;
   width: 100%;
-  background-color: var(--gray-l);
+  background-color: var(--c-decor-line-bg);
   margin-left: .5em;
   position: relative;
   top: .1em;
@@ -224,7 +227,7 @@ h2 {
 }
 h3 {
   font-size: 1.25em;
-  color: var(--dark);
+  color: var(--c-subheading-text);
   margin: 1em 0;
 }
 
@@ -233,7 +236,7 @@ h2::before {
   display: inline-block;
   width: 1em;
   margin-left: -1em;
-  color: var(--yellow);
+  color: var(--c-subheading-highlight);
 }
 
 
@@ -275,7 +278,7 @@ p.key-concept::before {
   text-transform: uppercase;
   letter-spacing: .1em;
   font-weight: 500;
-  color: var(--yellow);
+  color: var(--c-subheading-highlight);
   box-sizing: border-box;
 }
 
@@ -289,7 +292,7 @@ p.key-concept::before {
 }
 
 .body-wrapper a {
-  color: black;
+  color: var(--c-link-text);
 }
 
 .body-wrapper a[href^="http"]::after {
@@ -308,21 +311,21 @@ p.key-concept::before {
 
 .body-wrapper section ul {
   padding-left: 3em;
-  color: black;
+  color: var(--c-list-item-text);
 }
 .body-wrapper section ul li::marker {
-  color: var(--yellow);
+  color: var(--c-list-item-marker);
 }
 
 .body-wrapper section .example ul li::marker {
-  color: var(--dark);
+  color: var(--c-list-item-inner-marker);
 }
 
 
 aside {
   padding: 1em;
-  background-color: var(--green-l);
-  color: var(--dark-d);
+  background-color: var(--c-tip-bg);
+  color: var(--c-tip-text);
   font-size: .875em;
   margin: 1em 0;
   border-radius: .33em;
@@ -340,17 +343,18 @@ aside::before {
   font-size: 1em;
   font-weight: bold;
   margin-bottom: .75em;
-  color: var(--green);
+  color: var(--c-tip);
 }
 aside[data-title]::before {
   content: attr(data-title);
 }
 aside.info {
-  background-color: var(--purple);
+  background-color: var(--c-info-bg);
+  color: var(--c-info-text);
   position: relative;
 }
 aside.info::before {
-  color: var(--purple-d);
+  color: var(--c-info);
   background-image: url(/img/info.svg);
 }
 aside.collapsed {
@@ -395,20 +399,20 @@ aside[data-is-open]::after {
 }
 
 .body-wrapper code {
-  background-color: var(--gray-ll);
-  color: var(--dark-d);
+  background-color: var(--c-code-bg);
+  color: var(--c-code-text);
   padding: .1em .15em;
   font-size: .9em;
   border-radius: .15em;
   margin: 0 .1em;
 }
 .body-wrapper code.console {
-  background-color: transparent;
-  color: var(--green);
+  background-color:var(--c-code-console-bg);
+  color: var(--c-code-console-text);
 }
 
 .stage {
-  border: 1px solid var(--gray-l);
+  border: 1px solid var(--c-border-style);
   border-radius: .33em;
   overflow: hidden;
   margin-bottom: 1em;
@@ -416,13 +420,13 @@ aside[data-is-open]::after {
 .stage .example {
   font-size: 0.875em;
   padding: 1em;
-  border-top: 1px solid var(--gray-l);
+  border-top: 1px solid var(--c-border-style);
 }
 .stage pre {
   margin: -1em -1em 1em -1em;
 }
 .example ul li{
-  color: var(--dark);
+  color: var(--c-body-text);
 }
 
 /* Navigation
@@ -431,7 +435,7 @@ aside[data-is-open]::after {
 .navigation {
   position: sticky;
   top: 0;
-  background-color: white;
+  background-color: var(--c-nav-background);
   margin: 0 -1em 2em -1em;
   height: 3.25em;
   z-index: 50;
@@ -454,7 +458,7 @@ aside[data-is-open]::after {
 }
 .navigation a {
   text-decoration: none;
-  color: var(--dark);
+  color: var(--c-nav-link-text);
   display: inline-block;
   padding-left: 1em;
   position: relative;
@@ -472,43 +476,43 @@ aside[data-is-open]::after {
   background-color: transparent;
 }
 .navigation a:hover {
-  color: black;
+  color: var(--c-nav-link-text-hover);
 }
 
 .navigation a:hover::before {
-  background-color: var(--yellow);
+  background-color: var(--c-primary);
 }
 
 .navigation li[data-selected] > a {
   display: block;
   pointer-events: none;
-  color: black;
+  color: var(--c-nav-link-text-selected);
 }
 .navigation li[data-selected] > a::before {
-  background-color: var(--yellow);
+  background-color: var(--c-primary);
 }
 
 .navigation .selection {
   cursor: pointer;
-  border: 1px solid var(--gray-l);
+  border: 1px solid var(--c-nav-inner-border);
   padding: 0 .5em;
   margin: .5em 1em;
   border-radius: .33em;
   position: absolute;
   width: calc(100% - 2em);
-  background-color: white;
+  background-color: var(--c-nav-inner-bg);
   box-sizing: border-box;
 }
 
 .navigation .selection[data-is-open] {
-  box-shadow: 0 0 1em rgba(0, 0, 0, .1);
+  box-shadow: var(--nav-inner-shadow-opened);
 }
 
 .navigation .selection::before {
   content: '';
   display: block;
   border: .25em solid transparent;
-  border-top-color: var(--gray-l);
+  border-top-color: var(--c-nav-inner-border-top);
   position: absolute;
   right: 1em;
   top: 1em;
@@ -535,7 +539,7 @@ aside[data-is-open]::after {
     width: 12em;
     height: auto;
     flex: 0 0 12em;
-    background-color: transparent;
+    background-color: var(--c-nav-bg);
     margin-right: 1em;
     box-sizing: border-box;
   }
@@ -546,7 +550,7 @@ aside[data-is-open]::after {
     margin-bottom: 1em;
   }
   .selection > ul > li > a {
-    color: black;
+    color: var(--c-nav-link-text);
     font-weight: 500;
   }
   .navigation .selection[data-is-open] {

--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -375,6 +375,10 @@ p.key-concept::before {
   margin-left: .25em;
 }
 
+[theme="dark"] .body-wrapper a[href^="http"]::after {
+  filter: invert(100%);
+}
+
 .body-wrapper a[href^="http"]:hover::after {
   filter: invert(61%) sepia(94%) saturate(464%) hue-rotate(358deg) brightness(100%) contrast(105%);
 }

--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -25,6 +25,55 @@
   --purple-dimm: rgba(100, 108, 255, .05);
 }
 
+:root[theme="light"] {
+  --c-primary: var(--yellow);
+  --c-neutral: var(--white);
+  --c-neutral-inv: var(--black);
+  --c-highlight: var(--yellow);
+  --c-mute: var(--dark);
+
+  --c-body-text: var(--dark);
+  --c-body-bg: var(--white);
+  --c-heading-text: var(--black);
+  --c-subheading-text: var(--dark);
+  --c-subheading-highlight: var(--yellow);
+
+  --c-link-text: var(--color-neutral-inverse);
+  --c-link-text-hover: var(--dark-d);
+  --c-link-social-icon: var(--dark);
+
+  --c-nav-link-text: var(--black);
+  --c-nav-link-text-hover: var(--black);
+  --c-nav-background: var(--white);
+
+  --c-warning: var(--yellow);
+  --c-tip: var(--green);
+  --c-tip-accent: var(--green-l);
+  --c-error: var(--red);
+  --c-error-accent: var(--red-l);
+  --c-info: var(--purple-d);
+  --c-info-accent: var(--purple);
+
+  --c-warning-bg: var(--yellow-l);
+  --c-error-bg: var(--red-l);
+  --c-info-bg: var(--purple);
+  --c-tip-bg: var(--green-l);
+
+  --c-tip-text: var(--dark-d);
+  --c-warning-text: var(--dark);
+  --c-error-text: var(--dark);
+  --c-info-text: var(--dark-d);
+
+  --c-divider: var(--gray-l);
+  --c-border-style: var(--gray-l);
+
+  --c-code-bg: var(--gray-ll);
+  --c-code-text: var(--dark-d);
+
+  --color-selection-text: var(--black);
+  --color-selection-background: var(--yellow);
+}
+
 ::selection {
   background-color: var(--yellow);
   color: black;

--- a/docs/css/prism.css
+++ b/docs/css/prism.css
@@ -141,3 +141,130 @@ pre[class*="language-"] {
 	cursor: help;
 }
 
+/*
+  For dark themed code blocks.
+*/
+/**
+ * Coldark Theme for Prism.js
+ * Theme variation: Dark
+ * @author Armand Philippot <contact@armandphilippot.com>
+ * @homepage https://github.com/ArmandPhilippot/coldark-prism
+ * @license MIT
+ */
+
+ [theme="dark"] code[class*="language-"],
+ [theme="dark"] pre[class*="language-"] {
+   color: #e3eaf2;
+   text-shadow: 0 1px black;
+ }
+
+ [theme="dark"] :is(pre[class*="language-"]::-moz-selection,
+   pre[class*="language-"] ::-moz-selection,
+   code[class*="language-"]::-moz-selection,
+   code[class*="language-"] ::-moz-selection) {
+   background: #3c526d;
+ }
+
+ [theme="dark"] :is(pre[class*="language-"]::selection,
+   pre[class*="language-"] ::selection,
+   code[class*="language-"]::selection,
+   code[class*="language-"] ::selection) {
+   background: #3c526d;
+ }
+
+ [theme="dark"] :not(pre)>code[class*="language-"],
+ [theme="dark"] pre[class*="language-"] {
+   /* background: #1e1e1e;
+      */
+   background: #161618;
+ }
+
+ [theme="dark"] :is(.token.comment,
+   .token.prolog,
+   .token.doctype,
+   .token.cdata) {
+   color: #8da1b9;
+ }
+
+ [theme="dark"] .token.punctuation {
+   color: #e3eaf2;
+ }
+
+ [theme="dark"] :is(.token.delimiter.important,
+   .token.selector .parent,
+   .token.tag,
+   .token.tag .token.punctuation) {
+   color: #66cccc;
+ }
+
+ [theme="dark"] :is(.token.attr-name,
+   .token.boolean,
+   .token.boolean.important,
+   .token.number,
+   .token.constant,
+   .token.selector .token.attribute) {
+   color: #e6d37a;
+ }
+
+ [theme="dark"] :is(.token.class-name,
+   .token.key,
+   .token.parameter,
+   .token.property,
+   .token.property-access,
+   .token.variable) {
+   color: #6cb8e6;
+ }
+
+ [theme="dark"] :is(.token.attr-value,
+   .token.inserted,
+   .token.color,
+   .token.selector .token.value,
+   .token.string,
+   .token.string .token.url-link) {
+   color: #91d076;
+ }
+
+ [theme="dark"] :is(.token.builtin,
+   .token.keyword-array,
+   .token.package,
+   .token.regex) {
+   color: #f4adf4;
+ }
+
+ [theme="dark"] :is(.token.function,
+   .token.selector .token.class,
+   .token.selector .token.id) {
+   color: #c699e3;
+ }
+
+ [theme="dark"] :is(.token.atrule .token.rule,
+   .token.combinator,
+   .token.keyword,
+   .token.operator,
+   .token.pseudo-class,
+   .token.pseudo-element,
+   .token.selector,
+   .token.unit) {
+   color: #e9ae7e;
+ }
+
+ [theme="dark"] :is(.token.deleted,
+   .token.important) {
+   color: #cd6660;
+ }
+
+ [theme="dark"] :is(.token.keyword-this,
+   .token.this) {
+   color: #6cb8e6;
+ }
+
+ [theme="dark"] :is(.token.important,
+   .token.keyword-this,
+   .token.this,
+   .token.bold) {
+   font-weight: bold;
+ }
+
+ [theme="dark"] .token.delimiter.important {
+   font-weight: inherit;
+ }

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,18 @@
     <link rel="stylesheet" type="text/css" href="/css/index.css" />
     <link rel="stylesheet" type="text/css" href="/css/prism.css" />
     <script src="https://stirring-harmonious.arrow-js.com/script.js" data-site="NPEEWMAQ" defer></script>
+
+    <!-- Checks User Color-Scheme Preference -->
+    <script>
+      // assumes a Light Mode default
+        if (
+          localStorage.getItem('arrowjs-theme') === 'dark' ||
+          (window.matchMedia('(prefers-color-scheme: dark)').matches &&
+            !localStorage.getItem('arrowjs-theme'))
+        ) {
+          document.documentElement.setAttribute('theme', 'dark')
+        }
+    </script>
     <meta name="description" content="ArrowJS is a tool for programming reactive interfaces using native JavaScript. It’s 2Kb, requires no build tools, has no virtual DOM, and is blazing fast.">
 
     <!-- Twitter Meta Tags -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" theme="light">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@arrow-js/core",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@arrow-js/core",
-      "version": "1.0.0-alpha.5",
+      "version": "1.0.0-alpha.8",
       "license": "MIT",
       "devDependencies": {
         "@size-limit/preset-small-lib": "^4.9.2",


### PR DESCRIPTION
This adds dark mode to the documentation based on user request. 
I tried my best not to deviate too much from the existing color palette.

- [x]  Add new dark mode color variants.
- [x]  Add semantic names based on how the color is used.
- [x]  Load a dark or light theme based on system preferences.
- [x]  Add dark theme for code blocks.
- [ ]  Allow the user to manually choose their preference using a toggle.
- [ ]  Maintain the user's preferred theme on page reloads using local storage.
- [ ]  All colors have good contrast ratio and meet a11y guidelines.


@justin-schroeder  Any feedback on the colors, naming convention or approach is much appreciated. 

Resolves issue #6