### PR TITLE
Perf/create nodes

### DIFF
--- a/docs/benchmarks/benchmark.css
+++ b/docs/benchmarks/benchmark.css
@@ -1,0 +1,18 @@
+body {
+  font-family: sans-serif;
+}
+
+.benchmark-panel {
+  position: fixed;
+  top: 1em;
+  right: 1em;
+  background-color: rgba(75, 75, 75, .1);
+  padding: 1em;
+  border-radius: .25em;
+}
+
+.results {
+  margin-top: 1em;
+  font-weight: bold;
+  font-family: monospace;
+}

--- a/docs/benchmarks/creating.html
+++ b/docs/benchmarks/creating.html
@@ -26,6 +26,7 @@
       </div>
     </div>
     <table id="arrow"></table>
+    <div id="data"></div>
 
     <!-- ARROW TEST -->
     <script type="module">
@@ -60,21 +61,26 @@
         )
       }
 
+      html`
+      <ul>
+        ${() => data.rows.map((row) => html`<li>${() => row.label}</li>`)}
+      </ul>
+      `(document.getElementById('data'))
 
       html`
         <tbody>
           ${() => data.rows.map(row => html`
             <tr class="${() => row.id === data.selected ? 'danger' : false}">
               <td class="col-md-1">${() => row.id }</td>
-                <td class="col-md-4">
-                  <a @click="${() => {data.selected = row.id}}">${() => row.label }</a>
-                </td>
-                <td class="col-md-1">
-                  <a @click="${() => remove(row.id)}">
-                    Remove me
-                  </a>
-                </td>
-                <td class="col-md-6"></td>
+              <td class="col-md-4">
+                <a @click="${() => {data.selected = row.id}}">${() => row.label }</a>
+              </td>
+              <td class="col-md-1">
+                <a @click="${() => remove(row.id)}">
+                  Remove me
+                </a>
+              </td>
+              <td class="col-md-6"></td>
             </tr>`)}
         </tbody>
       `(document.getElementById('arrow'))

--- a/docs/benchmarks/creating.html
+++ b/docs/benchmarks/creating.html
@@ -41,7 +41,7 @@
 
       document.getElementById('run').addEventListener('click', async () => {
         const start = performance.now()
-        data.rows = buildData(10000)
+        data.rows = buildData(2)
         await nextTick()
         const end = performance.now()
         results.innerText = `${end - start}ms`
@@ -75,7 +75,7 @@
                   </a>
                 </td>
                 <td class="col-md-6"></td>
-            <tr>`)}
+            </tr>`)}
         </tbody>
       `(document.getElementById('arrow'))
     </script>
@@ -101,7 +101,7 @@
                   </a>
                 </td>
                 <td class="col-md-6"></td>
-            <tr>`
+            </tr>`
         }, '<tbody>') + '</tbody>'
         await new Promise(r => setTimeout(r, 0))
         const end = performance.now()

--- a/docs/benchmarks/creating.html
+++ b/docs/benchmarks/creating.html
@@ -42,7 +42,7 @@
 
       document.getElementById('run').addEventListener('click', async () => {
         const start = performance.now()
-        data.rows = buildData(2)
+        data.rows = buildData(10000)
         await nextTick()
         const end = performance.now()
         results.innerText = `${end - start}ms`

--- a/docs/benchmarks/creating.html
+++ b/docs/benchmarks/creating.html
@@ -47,7 +47,7 @@
         results.innerText = `${end - start}ms`
         let measurementHtml = ''
         for (const measurement in measurements) {
-          measurementHtml += '<div class="results">' + measurement + ': ' + `${measurements[measurement].reduce((sum, t) => sum += t, 0)}ms` + '</div>'
+          measurementHtml += '<div class="results">' + measurement + ': ' + `${measurements[measurement].reduce((sum, t) => sum += t, 0)}` + '</div>'
         }
         window.measurements = measurements
         internal.innerHTML = measurementHtml

--- a/docs/benchmarks/creating.html
+++ b/docs/benchmarks/creating.html
@@ -11,83 +11,101 @@
   </head>
   <body>
 
+    <div class="benchmark-panel">
+      <h2>Arrow</h2>
+      <button id="run">Create rows</button>
+      <div class="results">
+        Results: <span id="result"></span>
+      </div>
+      <div id="measurements">
+      </div>
+      <h2>Native</h2>
+      <button id="run-native">Create rows</button>
+      <div class="results">
+        Results: <span id="result-native"></span>
+      </div>
+    </div>
+    <table id="arrow"></table>
+
     <!-- ARROW TEST -->
     <script type="module">
-      import { reactive, html, nextTick } from '@src/index'
+      import { reactive, html, nextTick, measurements } from '@src/index'
       import { buildData } from './utils'
       const results = document.getElementById('result')
+      const internal = document.getElementById('measurements')
 
       const data = reactive({
+        selected: null,
         rows: []
       })
 
       document.getElementById('run').addEventListener('click', async () => {
         const start = performance.now()
         data.rows = buildData(10000)
-        mount(document.getElementById('arrow'))
         await nextTick()
         const end = performance.now()
         results.innerText = `${end - start}ms`
+        let measurementHtml = ''
+        for (const measurement in measurements) {
+          measurementHtml += '<div class="results">' + measurement + ': ' + `${measurements[measurement].reduce((sum, t) => sum += t, 0)}ms` + '</div>'
+        }
+        window.measurements = measurements
+        internal.innerHTML = measurementHtml
       })
 
-      const mount = html`
-        <ul>
-          ${() => data.rows.map(row => html`<li class="${() => row.id === data.selected ? 'danger' : false}">
-              <div class="col-md-1">${() => row.id }</div>
-                <div class="col-md-4">
+      function remove (id) {
+        data.rows.splice(
+          data.rows.findIndex((d) => d.id === id),
+          1
+        )
+      }
+
+
+      html`
+        <tbody>
+          ${() => data.rows.map(row => html`
+            <tr class="${() => row.id === data.selected ? 'danger' : false}">
+              <td class="col-md-1">${() => row.id }</td>
+                <td class="col-md-4">
                   <a @click="${() => {data.selected = row.id}}">${() => row.label }</a>
-                </div>
-                <div class="col-md-1">
+                </td>
+                <td class="col-md-1">
                   <a @click="${() => remove(row.id)}">
-                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                    Remove me
                   </a>
-                </div>
-                <div class="col-md-6"></div>
-            <li>`)}
-        </ul>
-      `
+                </td>
+                <td class="col-md-6"></td>
+            <tr>`)}
+        </tbody>
+      `(document.getElementById('arrow'))
     </script>
 
 
-
-
-
     <!-- NATIVE TEST -->
-    <div class="benchmark-panel">
-      <h2>Arrow</h2>
-      <button id="run">Create 1000 rows</button>
-      <div class="results">
-        Results: <span id="result"></span>
-      </div>
-      <h2>Native</h2>
-      <button id="run-native">Create 1000 rows</button>
-      <div class="results">
-        Results: <span id="result-native"></span>
-      </div>
-    </div>
-    <div id="arrow"></div>
     <script type="module">
       import { buildData } from './utils'
-      const ul = document.createElement('ul')
-      document.getElementById('arrow').appendChild(ul)
+      const table = document.getElementById('arrow')
       const results2 = document.getElementById('result-native')
       document.getElementById('run-native').addEventListener('click', async () => {
         const start = performance.now()
-        ul.innerHTML = buildData(10000).reduce((html, row) => {
-          return html += `<li class="foo">
-              <div class="col-md-1">${row.id }</div>
-                <div class="col-md-4">
+        table.innerHTML = buildData(10000).reduce((html, row) => {
+          return html += `
+            <tr class="foo">
+              <td class="col-md-1">${row.id }</td>
+                <td class="col-md-4">
                   <a>${row.label}</a>
-                </div>
-                <div class="col-md-1">
+                </td>
+                <td class="col-md-1">
                   <a>
-                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                    Remove me
                   </a>
-                </div>
-                <div class="col-md-6"></div>
-            <li>`
-        }, '')
+                </td>
+                <td class="col-md-6"></td>
+            <tr>`
+        }, '<tbody>') + '</tbody>'
+        await new Promise(r => setTimeout(r, 0))
         const end = performance.now()
+
         results2.innerText = `${end - start}ms`
       })
     </script>

--- a/docs/benchmarks/creating.html
+++ b/docs/benchmarks/creating.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="ArrowJS Benchmarks" />
+    <link rel="stylesheet" type="text/css" href="./benchmark.css" />
+    <meta name = "viewport" content = "width=device-width, minimum-scale=1.0, maximum-scale = 1.0, user-scalable = no">
+    <title>ArrowJS • Benchmarks</title>
+  </head>
+  <body>
+
+    <!-- ARROW TEST -->
+    <script type="module">
+      import { reactive, html, nextTick } from '@src/index'
+      import { buildData } from './utils'
+      const results = document.getElementById('result')
+
+      const data = reactive({
+        rows: []
+      })
+
+      document.getElementById('run').addEventListener('click', async () => {
+        const start = performance.now()
+        data.rows = buildData(10000)
+        mount(document.getElementById('arrow'))
+        await nextTick()
+        const end = performance.now()
+        results.innerText = `${end - start}ms`
+      })
+
+      const mount = html`
+        <ul>
+          ${() => data.rows.map(row => html`<li class="${() => row.id === data.selected ? 'danger' : false}">
+              <div class="col-md-1">${() => row.id }</div>
+                <div class="col-md-4">
+                  <a @click="${() => {data.selected = row.id}}">${() => row.label }</a>
+                </div>
+                <div class="col-md-1">
+                  <a @click="${() => remove(row.id)}">
+                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                  </a>
+                </div>
+                <div class="col-md-6"></div>
+            <li>`)}
+        </ul>
+      `
+    </script>
+
+
+
+
+
+    <!-- NATIVE TEST -->
+    <div class="benchmark-panel">
+      <h2>Arrow</h2>
+      <button id="run">Create 1000 rows</button>
+      <div class="results">
+        Results: <span id="result"></span>
+      </div>
+      <h2>Native</h2>
+      <button id="run-native">Create 1000 rows</button>
+      <div class="results">
+        Results: <span id="result-native"></span>
+      </div>
+    </div>
+    <div id="arrow"></div>
+    <script type="module">
+      import { buildData } from './utils'
+      const ul = document.createElement('ul')
+      document.getElementById('arrow').appendChild(ul)
+      const results2 = document.getElementById('result-native')
+      document.getElementById('run-native').addEventListener('click', async () => {
+        const start = performance.now()
+        ul.innerHTML = buildData(10000).reduce((html, row) => {
+          return html += `<li class="foo">
+              <div class="col-md-1">${row.id }</div>
+                <div class="col-md-4">
+                  <a>${row.label}</a>
+                </div>
+                <div class="col-md-1">
+                  <a>
+                    <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
+                  </a>
+                </div>
+                <div class="col-md-6"></div>
+            <li>`
+        }, '')
+        const end = performance.now()
+        results2.innerText = `${end - start}ms`
+      })
+    </script>
+  </body>
+</html>

--- a/docs/benchmarks/index.html
+++ b/docs/benchmarks/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="ArrowJS Benchmarks" />
+    <link rel="stylesheet" type="text/css" href="benchmarks.css" />
+    <meta name = "viewport" content = "width=device-width, minimum-scale=1.0, maximum-scale = 1.0, user-scalable = no">
+    <title>ArrowJS • Benchmarks</title>
+  </head>
+  <body>
+    <ul>
+      <li><a href="/benchmarks/creating.html">Creating nodes</a></li>
+    </ul>
+  </body>
+</html>

--- a/docs/benchmarks/textNodes.html
+++ b/docs/benchmarks/textNodes.html
@@ -5,14 +5,25 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="ArrowJS Benchmarks" />
-    <link rel="stylesheet" type="text/css" href="benchmarks.css" />
+    <link rel="stylesheet" type="text/css" href="./benchmark.css" />
     <meta name = "viewport" content = "width=device-width, minimum-scale=1.0, maximum-scale = 1.0, user-scalable = no">
     <title>ArrowJS • Benchmarks</title>
   </head>
   <body>
-    <ul>
-      <li><a href="/benchmarks/creating.html">Creating nodes</a></li>
-      <li><a href="/benchmarks/textNodes.html">Text nodes</a></li>
-    </ul>
+    <table id="arrow"></table>
+
+    <!-- ARROW TEST -->
+    <script type="module">
+      import { reactive, html } from '@src/index'
+
+      const data = reactive({
+        name: 'Justin',
+      })
+
+      html`
+        <input @input="${(e) => (data.name = e.target.value)}">
+        <div>${() => data.name}</div>
+      `(document.getElementById('arrow'))
+    </script>
   </body>
 </html>

--- a/docs/benchmarks/utils.js
+++ b/docs/benchmarks/utils.js
@@ -1,0 +1,76 @@
+let ID = 1
+
+function _random(max) {
+  return Math.round(Math.random() * 1000) % max
+}
+
+export function buildData(count = 1000) {
+  const adjectives = [
+    'pretty',
+    'large',
+    'big',
+    'small',
+    'tall',
+    'short',
+    'long',
+    'handsome',
+    'plain',
+    'quaint',
+    'clean',
+    'elegant',
+    'easy',
+    'angry',
+    'crazy',
+    'helpful',
+    'mushy',
+    'odd',
+    'unsightly',
+    'adorable',
+    'important',
+    'inexpensive',
+    'cheap',
+    'expensive',
+    'fancy',
+  ]
+  const colours = [
+    'red',
+    'yellow',
+    'blue',
+    'green',
+    'pink',
+    'brown',
+    'purple',
+    'brown',
+    'white',
+    'black',
+    'orange',
+  ]
+  const nouns = [
+    'table',
+    'chair',
+    'house',
+    'bbq',
+    'desk',
+    'car',
+    'pony',
+    'cookie',
+    'sandwich',
+    'burger',
+    'pizza',
+    'mouse',
+    'keyboard',
+  ]
+  const data = []
+  for (let i = 0; i < count; i++) {
+    data.push({
+      id: ID++,
+      label:
+        adjectives[_random(adjectives.length)] +
+        ' ' +
+        colours[_random(colours.length)] +
+        ' ' +
+        nouns[_random(nouns.length)],
+    })
+  }
+  return data
+}

--- a/docs/demos/calculator.html
+++ b/docs/demos/calculator.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="FormKit examples and specimens" />
+    <meta name="description" content="ArrowJS Demo" />
     <link rel="stylesheet" type="text/css" href="/css/index.css" />
     <link rel="stylesheet" type="text/css" href="calculator.css" />
     <link rel="stylesheet" type="text/css" href="demo-nav.css" />

--- a/docs/demos/carousel.html
+++ b/docs/demos/carousel.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="FormKit examples and specimens" />
+    <meta name="description" content="ArrowJS Demo" />
     <link rel="stylesheet" type="text/css" href="/css/index.css" />
     <link rel="stylesheet" type="text/css" href="carousel.css" />
     <link rel="stylesheet" type="text/css" href="demo-nav.css" />

--- a/docs/demos/dropdowns.html
+++ b/docs/demos/dropdowns.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="FormKit examples and specimens" />
+    <meta name="description" content="ArrowJS Demo" />
     <link rel="stylesheet" type="text/css" href="/css/index.css" />
     <link rel="stylesheet" type="text/css" href="/demos/dropdowns.css" />
     <link rel="stylesheet" type="text/css" href="demo-nav.css" />

--- a/docs/demos/fast-text.html
+++ b/docs/demos/fast-text.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="FormKit examples and specimens" />
+    <meta name="description" content="ArrowJS Demo" />
     <link rel="stylesheet" type="text/css" href="/css/index.css" />
     <link rel="stylesheet" type="text/css" href="fast-text.css" />
     <link rel="stylesheet" type="text/css" href="/demos/demo-nav.css" />

--- a/docs/demos/tabs.html
+++ b/docs/demos/tabs.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="FormKit examples and specimens" />
+    <meta name="description" content="ArrowJS Demo" />
     <link rel="stylesheet" type="text/css" href="/css/index.css" />
     <link rel="stylesheet" type="text/css" href="tabs.css" />
     <link rel="stylesheet" type="text/css" href="demo-nav.css" />

--- a/package.json
+++ b/package.json
@@ -46,14 +46,13 @@
     {
       "path": "dist/index.mjs",
       "limit": "3 KB",
-      "brotli": true,
       "gzip": true
     }
   ],
   "scripts": {
     "dev": "cd docs && vite --config=vite.config.ts",
     "build:docs": "cd docs && vite build --config=vite.config.ts",
-    "build": "npx ts-node ./build/pack.ts && pnpm minify",
+    "build": "npx ts-node ./build/pack.ts && pnpm minify && pnpm size",
     "test": "jest",
     "size": "size-limit",
     "minify": "node build/terser.js"

--- a/src/__tests__/__snapshots__/html.spec.ts.snap
+++ b/src/__tests__/__snapshots__/html.spec.ts.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`t can conditionally show/remove nodes 1`] = `"<div class=\\"checkout\\"><!----></div>"`;
+exports[`html can conditionally show/remove nodes 1`] = `"<div class=\\"checkout\\"><!----></div>"`;
 
-exports[`t can conditionally show/remove nodes 2`] = `"<div class=\\"checkout\\">Promo: <input type=\\"text\\"></div>"`;
+exports[`html can conditionally show/remove nodes 2`] = `"<div class=\\"checkout\\">Promo: <input type=\\"text\\"></div>"`;
 
-exports[`t can conditionally show/remove nodes 3`] = `"<div class=\\"checkout\\"><!----></div>"`;
+exports[`html can conditionally show/remove nodes 3`] = `"<div class=\\"checkout\\"><!----></div>"`;
 
-exports[`t can conditionally show/remove nodes 4`] = `"<div class=\\"checkout\\">Promo: <input type=\\"text\\"></div>"`;
+exports[`html can conditionally show/remove nodes 4`] = `"<div class=\\"checkout\\">Promo: <input type=\\"text\\"></div>"`;
 
-exports[`t can create a table with dynamic columns and rows 1`] = `
+exports[`html can create a table with dynamic columns and rows 1`] = `
 "<table>
       <tbody>
         <tr>
@@ -20,7 +20,7 @@ exports[`t can create a table with dynamic columns and rows 1`] = `
     </table>"
 `;
 
-exports[`t can place expression nested inside some elements inside a string 1`] = `
+exports[`html can place expression nested inside some elements inside a string 1`] = `
 "This is cool
       <div>
         And here is more text
@@ -29,7 +29,7 @@ exports[`t can place expression nested inside some elements inside a string 1`] 
       <span>Hello</span>"
 `;
 
-exports[`t can place expression nested inside some elements inside a string 2`] = `
+exports[`html can place expression nested inside some elements inside a string 2`] = `
 "This is cool
       <div>
         And here is more text
@@ -38,31 +38,31 @@ exports[`t can place expression nested inside some elements inside a string 2`] 
       <span>Hello</span>"
 `;
 
-exports[`t can remove and re-add multiple attributes 1`] = `
+exports[`html can remove and re-add multiple attributes 1`] = `
 "<div data-org=\\"braid\\">
       virginia
     </div>"
 `;
 
-exports[`t can remove and re-add multiple attributes 2`] = `
+exports[`html can remove and re-add multiple attributes 2`] = `
 "<div data-org=\\"braid\\" x-precinct=\\"cville\\">
       virginia
     </div>"
 `;
 
-exports[`t can remove and re-add multiple attributes 3`] = `
+exports[`html can remove and re-add multiple attributes 3`] = `
 "<div x-precinct=\\"cville\\">
       virginia
     </div>"
 `;
 
-exports[`t can remove and re-add multiple attributes 4`] = `
+exports[`html can remove and re-add multiple attributes 4`] = `
 "<div x-precinct=\\"cville\\" data-org=\\"other\\">
       california
     </div>"
 `;
 
-exports[`t can render a list with multiple repeated roots. 1`] = `
+exports[`html can render a list with multiple repeated roots. 1`] = `
 "<div>
       <h2>a</h2>
               <p>foobar</p><h2>b</h2>
@@ -71,41 +71,41 @@ exports[`t can render a list with multiple repeated roots. 1`] = `
     </div>"
 `;
 
-exports[`t can render a simple non-reactive list 1`] = `
+exports[`html can render a simple non-reactive list 1`] = `
 "Hello
       <ul>
         <li>a</li><li>b</li><li>c</li>
       </ul>"
 `;
 
-exports[`t can render a simple non-reactive list 2`] = `
+exports[`html can render a simple non-reactive list 2`] = `
 "Hello
       <ul>
         <li>a</li><li>b</li><li>c</li>
       </ul>"
 `;
 
-exports[`t can render a simple reactive list 1`] = `
+exports[`html can render a simple reactive list 1`] = `
 "Hello
       <ul>
         <li>a</li><li>b</li><li>c</li>
       </ul>"
 `;
 
-exports[`t can render a simple reactive list 2`] = `
+exports[`html can render a simple reactive list 2`] = `
 "Hello
       <ul>
         <li>a</li><li>b</li><li>c</li><li>next</li>
       </ul>"
 `;
 
-exports[`t can render an array of items and mutate an item in the array (#49) 1`] = `
+exports[`html can render an array of items and mutate an item in the array (#49) 1`] = `
 "<ul>
       <li>1</li><li>12</li><li>3</li>
     </ul>"
 `;
 
-exports[`t can render nested nodes with attribute expressions 1`] = `
+exports[`html can render nested nodes with attribute expressions 1`] = `
 "<ul data-country=\\"usa\\">
       <li data-abbr=\\"va\\">virginia</li><li data-abbr=\\"ne\\">nebraska</li><li data-abbr=\\"ca\\">california</li>
       <li data-first-abbr=\\"va\\">
@@ -114,7 +114,7 @@ exports[`t can render nested nodes with attribute expressions 1`] = `
     </ul> "
 `;
 
-exports[`t can render nested nodes with attribute expressions 2`] = `
+exports[`html can render nested nodes with attribute expressions 2`] = `
 "<ul data-country=\\"usa\\">
       <li data-abbr=\\"ca\\">california</li><li data-abbr=\\"ne\\">nebraska</li><li data-abbr=\\"va\\">virginia</li>
       <li data-first-abbr=\\"ca\\">

--- a/src/__tests__/html.spec.ts
+++ b/src/__tests__/html.spec.ts
@@ -233,6 +233,7 @@ describe('html', () => {
     expect(parent.innerHTML).toBe(`<ul>
       <li>c</li>
     </ul>`)
+    data.list.splice(0, 1)
     await nextTick()
     expect(parent.innerHTML).toBe(`<ul>
       <!---->

--- a/src/__tests__/html.spec.ts
+++ b/src/__tests__/html.spec.ts
@@ -6,7 +6,7 @@ interface User {
   id: number
 }
 
-describe('t', () => {
+describe('html', () => {
   it('can render simple strings', () => {
     const nodes = html`foo bar`().childNodes
     expect(nodes.length).toBe(1)
@@ -209,6 +209,33 @@ describe('t', () => {
     await nextTick()
     expect(parent.innerHTML).toBe(`<ul>
       <li>a</li><li>b</li><li>c</li><li>item</li>
+    </ul>`)
+  })
+
+  it('can remove items from a mapped list by splicing', async () => {
+    const data = reactive({
+      list: [{ name: 'a' }, { name: 'b' }, { name: 'c' }],
+    })
+    const parent = document.createElement('div')
+    html`<ul>
+      ${() => data.list.map((item) => html`<li>${() => item.name}</li>`)}
+    </ul>`(parent)
+    expect(parent.innerHTML).toBe(`<ul>
+      <li>a</li><li>b</li><li>c</li>
+    </ul>`)
+    data.list.splice(0, 1)
+    await nextTick()
+    expect(parent.innerHTML).toBe(`<ul>
+      <li>b</li><li>c</li>
+    </ul>`)
+    data.list.splice(0, 1)
+    await nextTick()
+    expect(parent.innerHTML).toBe(`<ul>
+      <li>c</li>
+    </ul>`)
+    await nextTick()
+    expect(parent.innerHTML).toBe(`<ul>
+      <!---->
     </ul>`)
   })
 
@@ -685,5 +712,21 @@ describe('t', () => {
     await nextTick()
     expect(x.foo).toBe('baz')
     expect(x.getAttribute('foo')).toBe(null)
+  })
+})
+
+describe('html text nodes', () => {
+  it('updates the the text node itself rather than creating new ones', async () => {
+    const parent = document.createElement('div')
+    const data = reactive({ text: 'foo' })
+    html`<span>${() => data.text}</span>`(parent)
+    const initialNode = parent.children[0].childNodes[0]
+    expect(initialNode).toBeInstanceOf(Text)
+    expect(initialNode.nodeValue).toBe('foo')
+    data.text = 'bar'
+    await nextTick()
+    const postNode = parent.children[0].childNodes[0]
+    expect(postNode.nodeValue).toBe('bar')
+    expect(initialNode === postNode).toBe(true)
   })
 })

--- a/src/__tests__/reactive.spec.ts.ts
+++ b/src/__tests__/reactive.spec.ts.ts
@@ -1,6 +1,6 @@
 import { nextTick, reactive, watch, ReactiveProxy } from '..'
 
-describe('r', () => {
+describe('reactive', () => {
   it('allows simple property access', () => {
     const data = reactive({ x: 123, y: 'abc' })
     expect(data.x).toBe(123)
@@ -28,7 +28,7 @@ describe('r', () => {
     data.foo = 'bar' // should not trigger since it wasnt recorded.
     data.a = 'hello'
     await nextTick()
-    expect(x.mock.calls.length).toBe(2)
+    expect(x).toHaveBeenCalledTimes(2)
     expect(x.mock.results[1].value).toBe('hellocan')
   })
 
@@ -41,10 +41,10 @@ describe('r', () => {
     data.$on('bar', listener)
     data.foo = 'hello'
     await nextTick()
-    expect(listener.mock.calls.length).toBe(0)
+    expect(listener).toHaveBeenCalledTimes(0)
     data.bar = 'baz'
     await nextTick()
-    expect(listener.mock.calls.length).toBe(1)
+    expect(listener).toHaveBeenCalledTimes(1)
     expect(listener.mock.calls[0]).toEqual(['baz', 'foo'])
   })
 
@@ -57,11 +57,11 @@ describe('r', () => {
     data.$on('bar', listener)
     data.bar = 'baz'
     await nextTick()
-    expect(listener.mock.calls.length).toBe(1)
+    expect(listener).toHaveBeenCalledTimes(1)
     data.$off('bar', listener)
     data.bar = 'fizz'
     await nextTick()
-    expect(listener.mock.calls.length).toBe(1)
+    expect(listener).toHaveBeenCalledTimes(1)
   })
 
   it('can track dependencies on shadow properties when they are lit up', async () => {
@@ -72,16 +72,16 @@ describe('r', () => {
     const hasName = () => (data.value > 0.5 ? data.name : 'nothing')
     const setValue = jest.fn()
     watch(hasName, setValue)
-    expect(setValue.mock.calls.length).toBe(1)
+    expect(setValue).toHaveBeenCalledTimes(1)
     data.name = 'Jonny'
     await nextTick()
-    expect(setValue.mock.calls.length).toBe(1)
+    expect(setValue).toHaveBeenCalledTimes(1)
     data.value = 1
     await nextTick()
-    expect(setValue.mock.calls.length).toBe(2)
+    expect(setValue).toHaveBeenCalledTimes(2)
     data.name = 'Jill'
     await nextTick()
-    expect(setValue.mock.calls.length).toBe(3)
+    expect(setValue).toHaveBeenCalledTimes(3)
   })
 
   it('consolidates identical watcher expressions', async () => {
@@ -90,10 +90,10 @@ describe('r', () => {
     })
     const callback = jest.fn()
     watch(() => data.list.map((item: string) => item), callback)
-    expect(callback.mock.calls.length).toBe(1)
+    expect(callback).toHaveBeenCalledTimes(1)
     data.list.unshift('first')
     await nextTick()
-    expect(callback.mock.calls.length).toBe(2)
+    expect(callback).toHaveBeenCalledTimes(2)
   })
 
   it('untracks dependencies that fall back into shadow', async () => {
@@ -104,17 +104,17 @@ describe('r', () => {
     const hasName = () => (data.value > 0.5 ? data.name : 'nothing')
     const setValue = jest.fn()
     watch(hasName, setValue)
-    expect(setValue.mock.calls.length).toBe(1)
+    expect(setValue).toHaveBeenCalledTimes(1)
     data.value = 1
     data.name = 'hello'
     await nextTick()
-    expect(setValue.mock.calls.length).toBe(2)
+    expect(setValue).toHaveBeenCalledTimes(2)
     data.value = 0
     await nextTick()
-    expect(setValue.mock.calls.length).toBe(3)
+    expect(setValue).toHaveBeenCalledTimes(3)
     data.name = 'molly'
     await nextTick()
-    expect(setValue.mock.calls.length).toBe(3)
+    expect(setValue).toHaveBeenCalledTimes(3)
   })
 
   it('is able to track dependencies on nested tracking calls', async () => {
@@ -135,15 +135,15 @@ describe('r', () => {
       }
     }
     watch(hasName, hasNameCb)
-    expect(hasNameCb.mock.calls.length).toBe(1)
-    expect(printNameCb.mock.calls.length).toBe(0)
+    expect(hasNameCb).toHaveBeenCalledTimes(1)
+    expect(printNameCb).toHaveBeenCalledTimes(0)
     data.value = 2
     await nextTick()
-    expect(printNameCb.mock.calls.length).toBe(1) // Previously shadowed
-    expect(hasNameCb.mock.calls.length).toBe(2)
+    expect(printNameCb).toHaveBeenCalledTimes(1) // Previously shadowed
+    expect(hasNameCb).toHaveBeenCalledTimes(2)
     data.name = 'hello'
     await nextTick()
-    expect(hasNameCb.mock.calls.length).toBe(3)
+    expect(hasNameCb).toHaveBeenCalledTimes(3)
   })
 
   it('is able to react to nested reactive object mutations', async () => {
@@ -153,10 +153,10 @@ describe('r', () => {
     })
     const callback = jest.fn()
     watch(() => data.user.last, callback)
-    expect(callback.mock.calls.length).toBe(1)
+    expect(callback).toHaveBeenCalledTimes(1)
     data.user.last = 'Poppies'
     await nextTick()
-    expect(callback.mock.calls.length).toBe(2)
+    expect(callback).toHaveBeenCalledTimes(2)
     expect(callback.mock.calls[1][0]).toBe('Poppies')
   })
 
@@ -167,7 +167,7 @@ describe('r', () => {
     const callback = jest.fn()
     data.list[0].$on('name', callback)
     data.list[0] = { name: 'fred' }
-    expect(callback.mock.calls.length).toBe(0)
+    expect(callback).toHaveBeenCalledTimes(0)
   })
 
   it('can merge existing recursive object observers', () => {
@@ -180,8 +180,8 @@ describe('r', () => {
     data.users[0].$on('name', listObserver)
     user.$on('name', userObserver)
     data.users[0] = user
-    expect(listObserver.mock.calls.length).toBe(1)
-    expect(userObserver.mock.calls.length).toBe(0)
+    expect(listObserver).toHaveBeenCalledTimes(1)
+    expect(userObserver).toHaveBeenCalledTimes(0)
   })
 
   it('is able to de-register nested dependencies when they move into logical shadow', async () => {
@@ -194,17 +194,17 @@ describe('r', () => {
       () => (data.first === 'Justin' ? '@jpschroeder' : data.user.username),
       callback
     )
-    expect(callback.mock.calls.length).toBe(1)
+    expect(callback).toHaveBeenCalledTimes(1)
     data.user.username = 'poppy22'
     await nextTick()
-    expect(callback.mock.calls.length).toBe(2)
+    expect(callback).toHaveBeenCalledTimes(2)
     expect(callback.mock.calls[1][0]).toBe('poppy22')
     data.first = 'Justin'
     await nextTick()
-    expect(callback.mock.calls.length).toBe(3)
+    expect(callback).toHaveBeenCalledTimes(3)
     data.user.username = 'jenny33'
     await nextTick()
-    expect(callback.mock.calls.length).toBe(3)
+    expect(callback).toHaveBeenCalledTimes(3)
   })
 
   it('will notify the root property of array mutations', () => {
@@ -214,7 +214,36 @@ describe('r', () => {
     const callback = jest.fn()
     data.$on('list', callback)
     data.list.push('c')
-    expect(callback.mock.calls.length).toBe(1)
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('will notify the root property when the array is empty', () => {
+    const data = reactive({
+      list: ['a', 'b'],
+    })
+    const callback = jest.fn()
+    data.$on('list', callback)
+    data.list.length = 0
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('will notify the root property when the array spliced to empty', async () => {
+    const data = reactive({
+      list: [] as { name: string; id: number }[],
+    })
+    const callback = jest.fn()
+    data.$on('list', callback)
+    data.list = [
+      { name: 'a', id: 145 },
+      { name: 'b', id: 567 },
+    ] as ReactiveProxy<{ name: string; id: number }[]>
+    expect(callback).toHaveBeenCalledTimes(1)
+    data.list.splice(0, 1)
+    await nextTick()
+    expect(callback).toHaveBeenCalledTimes(2)
+    data.list.splice(0, 1)
+    expect(callback).toHaveBeenCalledTimes(3)
+    expect(data.list).toEqual([])
   })
 
   it('will notify the root property of array mutations on newly assigned nested r', () => {
@@ -224,11 +253,11 @@ describe('r', () => {
     const callback = jest.fn()
     data.$on('list', callback)
     data.list.push('c')
-    expect(callback.mock.calls.length).toBe(1)
+    expect(callback).toHaveBeenCalledTimes(1)
     data.list = reactive(['a', 'b'])
-    expect(callback.mock.calls.length).toBe(2)
+    expect(callback).toHaveBeenCalledTimes(2)
     data.list.push('c')
-    expect(callback.mock.calls.length).toBe(3)
+    expect(callback).toHaveBeenCalledTimes(3)
   })
 
   it('will notify root observers on objects of property mutations', () => {
@@ -241,7 +270,7 @@ describe('r', () => {
     const callback = jest.fn()
     data.$on('food', callback)
     data.food.breakfast = 'eggs'
-    expect(callback.mock.calls.length).toBe(1)
+    expect(callback).toHaveBeenCalledTimes(1)
   })
 
   it('can automatically swap object dependency and update listeners on it’s properties', () => {
@@ -252,11 +281,11 @@ describe('r', () => {
     })
     const callback = jest.fn()
     data.user.$on('name', callback)
-    expect(callback.mock.calls.length).toBe(0)
+    expect(callback).toHaveBeenCalledTimes(0)
     data.user.name = 'Dustin'
-    expect(callback.mock.calls.length).toBe(1)
+    expect(callback).toHaveBeenCalledTimes(1)
     data.user = { name: 'Frank' } as ReactiveProxy<{ name: 'Frank' }>
-    expect(callback.mock.calls.length).toBe(2)
+    expect(callback).toHaveBeenCalledTimes(2)
   })
 
   it('can observe multiple data objects in watcher', async () => {

--- a/src/__tests__/watch.spec.ts
+++ b/src/__tests__/watch.spec.ts
@@ -13,18 +13,13 @@ describe('w', () => {
     })
 
     watch(callback)
-
     await nextTick()
     expect(callback).toHaveBeenCalledTimes(1)
-
     d.value = 10
     await nextTick()
-
     expect(callback).toHaveBeenCalledTimes(2)
-
     d.value = 20
     await nextTick()
-
     expect(callback).toHaveBeenCalledTimes(3)
   })
 
@@ -114,5 +109,29 @@ describe('w', () => {
     await nextTick()
     expect(cb1).toHaveBeenCalledTimes(1)
     expect(d.value).toStrictEqual(2)
+  })
+
+  it('will call a watcher when a dependant array is changed to empty', async () => {
+    const data = reactive({ list: ['A', 'B', 'C'] })
+    const callback = jest.fn()
+    watch(() => data.list, callback)
+    expect(callback).toHaveBeenCalledTimes(1)
+    data.list.length = 0
+    await nextTick()
+    expect(callback).toHaveBeenCalledTimes(2)
+  })
+
+  it('will call a watcher when a dependant array is spliced to empty', async () => {
+    const data = reactive({ list: ['A', 'B'] })
+    const callback = jest.fn()
+    watch(() => data.list, callback)
+    expect(callback).toHaveBeenCalledTimes(1)
+    data.list.splice(0, 1)
+    await nextTick()
+    expect(callback).toHaveBeenCalledTimes(2)
+    data.list.splice(0, 1)
+    await nextTick()
+    expect(callback).toHaveBeenCalledTimes(3)
+    expect(data.list).toEqual([])
   })
 })

--- a/src/common.ts
+++ b/src/common.ts
@@ -81,19 +81,14 @@ export function queue(fn: ObserverCallback): ObserverCallback {
   }
 }
 
-/**
- * Given a string, sanitize for inclusion in html.
- * @param str - A string to sanitize.
- * @returns
- */
-export const sanitize = (str: string): string => {
-  return str === '<!---->'
-    ? str
-    : str.replace(/[<>]/g, (m) => (m === '>' ? '&gt;' : '&lt;'))
-}
-
 export const measurements: Record<string, number[]> = {}
 
+/**
+ * A simple benchmarking function.
+ * @param label - A label for the measurement
+ * @param fn - A function to measure or a number to record
+ * @returns
+ */
 export function measure<T = unknown>(
   label: string,
   fn: CallableFunction | number

--- a/src/common.ts
+++ b/src/common.ts
@@ -91,3 +91,13 @@ export const sanitize = (str: string): string => {
     ? str
     : str.replace(/[<>]/g, (m) => (m === '>' ? '&gt;' : '&lt;'))
 }
+
+export const measurements: Record<string, number[]> = {}
+
+export function measure(label: string, fn: CallableFunction): void {
+  const start = performance.now()
+  fn()
+  const result = performance.now() - start
+  if (!measurements[label]) measurements[label] = [result]
+  else measurements[label].push(result)
+}

--- a/src/common.ts
+++ b/src/common.ts
@@ -94,10 +94,16 @@ export const sanitize = (str: string): string => {
 
 export const measurements: Record<string, number[]> = {}
 
-export function measure(label: string, fn: CallableFunction): void {
+export function measure<T = unknown>(
+  label: string,
+  fn: CallableFunction | number
+): T {
   const start = performance.now()
-  fn()
-  const result = performance.now() - start
+  const isFn = typeof fn === 'function'
+  label = isFn ? `${label} (ms)` : `${label} (calls)`
+  const x = isFn ? fn() : fn
+  const result = isFn ? performance.now() - start : fn
   if (!measurements[label]) measurements[label] = [result]
   else measurements[label].push(result)
+  return x
 }

--- a/src/html.ts
+++ b/src/html.ts
@@ -483,7 +483,6 @@ function createPartial(group = Symbol()): TemplatePartial {
     const subPartial = createPartial(group)
     let startChunking = 0
     let lastNode: ChildNode = previousChunks[0].dom[0]
-    console.log(chunks.length)
     // If this is an empty update, we need to "placehold" its spot in the dom
     // with an empty placeholder chunk.
     if (!chunks.length) addPlaceholderChunk(document.createComment(''))

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,3 +21,6 @@ export { nextTick } from './common'
 export type { ArrowTemplate } from './html'
 
 export type { ReactiveProxy } from './reactive'
+
+// TODO: REMOVE THIS
+export { measurements } from './common'

--- a/src/reactive.ts
+++ b/src/reactive.ts
@@ -363,7 +363,10 @@ function reactiveMerge(
  * @param  {CallableFunction} after?
  * @returns unknown
  */
-export function w(fn: CallableFunction, after?: CallableFunction): unknown {
+export function w<
+  T extends (...args: any[]) => unknown,
+  F extends (...args: any[]) => any | undefined
+>(fn: T, after?: F): F extends undefined ? ReturnType<T> : ReturnType<F> {
   const trackingId = Symbol()
   if (!dependencyCollector.has(trackingId)) {
     dependencyCollector.set(trackingId, new Map())

--- a/src/reactive.ts
+++ b/src/reactive.ts
@@ -76,8 +76,7 @@ export interface DependencyProps {
  */
 export type ReactiveProxy<T> = {
   [K in keyof T]: T[K] extends DataSource ? ReactiveProxy<T[K]> : T[K]
-} &
-  DataSource &
+} & DataSource &
   DependencyProps
 
 type ReactiveProxyParent = [
@@ -369,8 +368,10 @@ export function w(fn: CallableFunction, after?: CallableFunction): unknown {
   if (!dependencyCollector.has(trackingId)) {
     dependencyCollector.set(trackingId, new Map())
   }
-  let currentDeps: Map<ReactiveProxy<DataSource>, Set<DataSourceKey>> =
-    new Map()
+  let currentDeps: Map<
+    ReactiveProxy<DataSource>,
+    Set<DataSourceKey>
+  > = new Map()
   const queuedCallFn = queue(callFn)
   function callFn() {
     dependencyCollector.set(trackingId, new Map())

--- a/src/reactive.ts
+++ b/src/reactive.ts
@@ -269,6 +269,7 @@ export function r<T extends DataSource>(
     },
   }) as ReactiveProxy<T>
 
+  if (state.p) proxy._p = state.p
   // Before we return the proxy object, quickly map through the children
   // and set the parents (this is only run on the initial setup).
   children.map((c) => {
@@ -384,7 +385,6 @@ export function w<
       Set<DataSourceKey>
     >
     dependencyCollector.delete(trackingId)
-
     // Disable existing properties
     currentDeps.forEach((propertiesToUnobserve, proxy) => {
       const newProperties = newDeps.get(proxy)


### PR DESCRIPTION
In this PR:

- Improved the velocity of creating nodes by ~2x.
- Changed chunking algorithm to explicitly raw `Text` nodes, improving update performance.
- Direct `Text` mutations no longer need explicit sanitation.
- Fixes a bug when replacing a reactive object where there parent object reference did not transfer properly. (fixes the bug although this entire concept is on the chopping block in favor of a `WeakMap` relationship between objects).