### PR TITLE
Add support for emitting IIFE

### DIFF
--- a/build/pack.ts
+++ b/build/pack.ts
@@ -27,6 +27,20 @@ async function baseBuild() {
   ])
 }
 
+async function iifeBuild() {
+  info('Rolling up IIFE')
+  await execa('npx', [
+    'rollup',
+    '-c',
+    'rollup.config.ts',
+    '--configPlugin',
+    'typescript',
+    '--environment',
+    'BUILD:iife'
+  ])
+}
+
+
 async function typesBuild() {
   info('Rolling up types')
   await execa('npx', [
@@ -51,6 +65,7 @@ async function removeArtifacts() {
   try {
     await clean()
     await baseBuild()
+    await iifeBuild()
     await typesBuild()
     await removeArtifacts()
     success('Build complete')

--- a/build/terser.js
+++ b/build/terser.js
@@ -49,3 +49,53 @@ let result = await minify(fs.readFileSync(inputFile, 'utf-8'), {
 // Output the minified file and the map.
 fs.writeFileSync(outputFile, result.code, 'utf8')
 fs.writeFileSync(outputFile + '.map', result.map, 'utf8')
+
+// IIFE
+const iifeInputFile = fileURLToPath(new URL('../dist/index.js', import.meta.url))
+const iifeTsSourceMap = fileURLToPath(
+  new URL('../dist/index.js.map', import.meta.url)
+)
+const iifeOutputFile = fileURLToPath(
+  new URL('../dist/index.min.js', import.meta.url)
+)
+
+let iifeResult = await minify(fs.readFileSync(iifeInputFile, 'utf-8'), {
+  mangle: {
+    module: true,
+    reserved: [
+      '_k',
+      '_h',
+      '_g',
+      '_m',
+      '$on',
+      '$off',
+      '_do',
+      '_tk',
+      '_em',
+      '_p',
+      'key',
+      't',
+      'r',
+      'o',
+      'op',
+      'dc',
+      'html',
+      'exp',
+      'dom',
+      'tpl',
+      '$arrow'
+    ],
+  },
+  compress: {
+    ecma: '2015',
+  },
+  ecma: '2015',
+  sourceMap: {
+    content: fs.readFileSync(iifeTsSourceMap, 'utf-8'),
+    url: 'index.min.js.map',
+  },
+})
+
+// Output the minified file and the map.
+fs.writeFileSync(iifeOutputFile, iifeResult.code, 'utf8')
+fs.writeFileSync(iifeOutputFile + '.map', iifeResult.map, 'utf8')

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -14,6 +14,17 @@ if (process.env.BUILD === 'types') {
   plugins.push(dts())
   output.file = 'dist/index.d.ts'
   input = 'dist/index.d.ts'
+} else if (process.env.BUILD === 'iife') {
+  output.sourcemap = true
+  output.name = '$arrow'
+  output.format = 'iife'
+  output.file = 'dist/index.js'
+  plugins.push(
+    typescript({
+      sourceMap: false,
+      exclude: ['rollup.config.ts', 'src/__tests__/**'],
+    })
+  )
 } else {
   output.sourcemap = true
   plugins.push(


### PR DESCRIPTION
This PR adds support for emitting IIFEs to be used in legacy mode.
The emitted files are `dist/index.js`, `dist/index.min.js` and their corresponding `.map` files.
The functions are exported under a global variable `$arrow`, thus, the usage would be:
`$arrow.r(...); $arrow.w(...); $arrow.t(...)`

It would be nice to have individual variables exported for each function, like `$r(...); $w(...); $t(...)` - this would be awesome, actually.

Cheers! Keep up the good work!