### PR TITLE
Fixes calculator special symbols render

### DIFF
--- a/docs/demos/components/calculator.js
+++ b/docs/demos/components/calculator.js
@@ -8,8 +8,8 @@ const data = reactive({
 const operations = {
   '+': (carry, input) => carry + input,
   '-': (carry, input) => carry - input,
-  '&#xf7;': (carry, input) => carry / input,
-  '&times;': (carry, input) => carry * input,
+  '\u00f7': (carry, input) => carry / input,
+  '\u00d7': (carry, input) => carry * input,
 }
 
 function calculate() {


### PR DESCRIPTION
The [calculator demo](https://www.arrow-js.com/demos/calculator.html) renders raw entity codes for the multiply and divide symbols in the subtitle (tested in Firefox and Safari macOS):

<img width="418" alt="Says 3 &times; 2 &#×f7; 3" src="https://github.com/justin-schroeder/arrow-js/assets/37649/6e8cfe93-8049-4337-a2f4-90b4d190bd74">

By using JavaScript escape codes, we can avoid this:

<img width="418" alt="Says 5 × 3 ÷ 2" src="https://github.com/justin-schroeder/arrow-js/assets/37649/18a2bee1-051b-403b-9e87-2725aef031df">

Instead of JavaScript escapes, we could enter the raw UTF-8 encoded symbols directly into the JavaScript file, happy to change that if you prefer.