### PR TITLE
feat(skill): add accessibility reference

### DIFF
--- a/packages/skill/resources/skill/SKILL.md
+++ b/packages/skill/resources/skill/SKILL.md
@@ -14,6 +14,7 @@ Use this skill when the project uses Arrow packages such as `@arrow-js/core`, `@
    - Getting started / scaffold shape: `references/getting-started.md`
    - API surface and package split: `references/api.md`
    - Common patterns and examples: `references/examples.md`
+   - Accessibility principles and APG index: `references/accessibility.md`
 3. Prefer idiomatic Arrow:
    - `reactive()` for state
    - `html` tagged templates for DOM
@@ -28,6 +29,7 @@ Use this skill when the project uses Arrow packages such as `@arrow-js/core`, `@
 - Pass reactive state directly as component props unless narrowing is clearly needed.
 - Compose views with nested templates and component calls instead of imperative DOM work.
 - Keep no-build Arrow honest. Avoid introducing benchmark-only patterns or unnecessary compiler assumptions.
+- Semantic HTML first; reactive `aria-*` needs callable expressions. See `references/accessibility.md` before building interactive widgets.
 - In framework apps, remember the package split:
   - `@arrow-js/core`: reactive state, templates, components, watch
   - `@arrow-js/framework`: render, async component runtime, boundary
@@ -39,3 +41,4 @@ Use this skill when the project uses Arrow packages such as `@arrow-js/core`, `@
 - `references/getting-started.md`
 - `references/api.md`
 - `references/examples.md`
+- `references/accessibility.md`

--- a/packages/skill/resources/skill/references/accessibility.md
+++ b/packages/skill/resources/skill/references/accessibility.md
@@ -1,0 +1,24 @@
+# Arrow Accessibility Notes
+
+## Principles
+
+- Semantic HTML first: `<button>`, `<a href>`, `<details>`, `<dialog>`, `<label>`, landmarks. No ARIA is better than wrong ARIA.
+- Every interactive element needs an accessible name: visible text, `<label>` for inputs, `alt` for images (empty `alt=""` if decorative), `aria-label` only for icon-only controls.
+- Keep `:focus-visible` styles. Never strip the outline without an equivalent.
+- Keyboard parity: if `@click` isn't on a native `<button>`/`<a>`, you should be using one.
+- Use `.key(...)` on dynamic lists so focused items survive reorders.
+- `role="menu"` is for desktop-app action menus only, not nav or generic dropdowns.
+
+## Reactive ARIA
+
+- Callable expressions (`${() => ...}`) keep attributes reactive. Plain values render once.
+- Arrow removes an attribute when an expression returns JS `false`. Correct for boolean HTML attributes (`hidden`, `disabled`, `readonly`). Wrong for enumerated ARIA states where absence ≠ `"false"`.
+- For `aria-expanded`, `aria-pressed`, `aria-selected`, `aria-checked`, `aria-current`, pass strings:
+  - ✅ `aria-expanded="${() => state.open ? 'true' : 'false'}"`
+  - ❌ `aria-expanded="${() => state.open}"` (removes attribute when closed)
+
+## Widget patterns
+
+- Prefer a native element when one exists (`<details>`, `<dialog>`, `<input type="checkbox" role="switch">`) before reaching for an APG pattern.
+- Before building accordions, dialogs, comboboxes, tabs, etc., check the WAI-ARIA Authoring Practices Guide: https://www.w3.org/WAI/ARIA/apg/patterns/
+- Implement the pattern's keyboard section (arrow keys, Home/End, Escape, typeahead). Roles and state without keyboard handlers leave the widget unusable.

--- a/packages/skill/resources/skill/references/api.md
+++ b/packages/skill/resources/skill/references/api.md
@@ -14,7 +14,10 @@ Use this reference when you need the main runtime semantics quickly.
 - `${data.foo}` is static.
 - `${() => data.foo}` stays live.
 - Return arrays of templates to render lists.
+  - Reactive lists need a callable wrap: `${() => items.map(item => html\`...\`.key(item.id))}`. A bare `${items.map(...)}` renders once.
 - Use `.key(...)` when DOM identity must survive reorders.
+- Event handlers must be assignable to `EventListener`.
+  - Narrower TS signatures like `(e: KeyboardEvent) => void` fail typecheck — Widen and cast inside: `const onKey: EventListener = (e) => { const key = (e as KeyboardEvent).key; ... }`.
 - **Attribute expressions must be the entire attribute value.** Partial interpolation like `id="tab-${key}"` throws `Invalid HTML position`.
   - Precompute: `const tabId = \`tab-${key}\`` → `id="${tabId}"`. Applies to class, `data-*`, hrefs, etc.
   - Text slots (`<span>tab-${key}</span>`) are unaffected.

--- a/packages/skill/resources/skill/references/api.md
+++ b/packages/skill/resources/skill/references/api.md
@@ -15,6 +15,9 @@ Use this reference when you need the main runtime semantics quickly.
 - `${() => data.foo}` stays live.
 - Return arrays of templates to render lists.
 - Use `.key(...)` when DOM identity must survive reorders.
+- **Attribute expressions must be the entire attribute value.** Partial interpolation like `id="tab-${key}"` throws `Invalid HTML position`.
+  - Precompute: `const tabId = \`tab-${key}\`` → `id="${tabId}"`. Applies to class, `data-*`, hrefs, etc.
+  - Text slots (`<span>tab-${key}</span>`) are unaffected.
 
 ## `component()`
 

--- a/packages/skill/resources/skill/references/examples.md
+++ b/packages/skill/resources/skill/references/examples.md
@@ -50,6 +50,35 @@ export function routeToPage(url: string) {
 }
 ```
 
+## Disclosure with reactive ARIA
+
+```ts
+import { html, reactive } from '@arrow-js/core'
+
+const state = reactive({ open: false })
+
+html`
+  <button
+    aria-expanded="${() => (state.open ? 'true' : 'false')}"
+    aria-controls="panel"
+    @click="${() => (state.open = !state.open)}"
+  >
+    Details
+  </button>
+  <div id="panel" hidden="${() => !state.open}">…</div>
+`
+```
+
+## Live region
+
+```ts
+import { html, reactive } from '@arrow-js/core'
+
+const status = reactive({ message: '' })
+
+html`<div role="status">${() => status.message}</div>`
+```
+
 ## SSR + hydration
 
 ```ts

--- a/packages/skill/resources/skill/references/examples.md
+++ b/packages/skill/resources/skill/references/examples.md
@@ -79,6 +79,68 @@ const status = reactive({ message: '' })
 html`<div role="status">${() => status.message}</div>`
 ```
 
+## Tabs with APG keyboard handler
+
+```ts
+import { html, reactive } from '@arrow-js/core'
+
+const labels = ['Overview', 'Details', 'History']
+const state = reactive({ active: 0 })
+
+const onKey: EventListener = (e) => {
+  const ev = e as KeyboardEvent
+  const max = labels.length - 1
+  const next =
+    ev.key === 'ArrowRight' ? (state.active === max ? 0 : state.active + 1) :
+    ev.key === 'ArrowLeft'  ? (state.active === 0 ? max : state.active - 1) :
+    ev.key === 'Home' ? 0 : ev.key === 'End' ? max : -1
+  if (next < 0) return
+  ev.preventDefault()
+  state.active = next
+  queueMicrotask(() => (e.currentTarget as HTMLElement).children[next]?.focus())
+}
+
+html`
+  <div role="tablist" aria-label="Sections" @keydown="${onKey}">
+    ${() => labels.map((label, i) => html`<button
+      role="tab"
+      aria-selected="${() => (state.active === i ? 'true' : 'false')}"
+      tabindex="${() => (state.active === i ? '0' : '-1')}"
+      @click="${() => (state.active = i)}"
+    >${label}</button>`.key(i))}
+  </div>
+`
+```
+
+Roving tabindex (string values!), Arrow/Home/End keys, and focus following selection via `queueMicrotask` so it runs after the DOM update. Roles and `aria-selected` without this handler leave the widget unreachable by keyboard.
+
+## Imperative DOM bridge (native `<dialog>`)
+
+```ts
+import { html, reactive, watch } from '@arrow-js/core'
+
+const state = reactive({ open: false })
+
+html`
+  <button @click="${() => (state.open = true)}">Delete</button>
+  <dialog id="confirm" @close="${() => (state.open = false)}">
+    <form method="dialog">
+      <p>Delete this item?</p>
+      <button value="cancel">Cancel</button>
+      <button value="confirm">Delete</button>
+    </form>
+  </dialog>
+`(document.body)
+
+watch(() => {
+  const dlg = document.getElementById('confirm') as HTMLDialogElement | null
+  if (!dlg) return
+  state.open ? !dlg.open && dlg.showModal() : dlg.open && dlg.close()
+})
+```
+
+Arrow has no ref primitive. To drive an imperative API (`<dialog>.showModal()`, `<video>.play()`, `.focus()`) from reactive state, use `watch()` + `querySelector` after mount. `@close` syncs state back when Escape or a `method="dialog"` form submits.
+
 ## SSR + hydration
 
 ```ts


### PR DESCRIPTION
Closes #118.

## Summary

Adds accessibility guidance to the Arrow agent skill — minimalist shape per the "keep token count low" request in the issue thread. Also documents the Arrow template-parser rule for dynamic attribute ids, which is load-bearing for ARIA wiring.

**Commits**
1. `feat(skill): add accessibility reference` — `references/accessibility.md` (new, 24 lines), two examples in `references/examples.md`, and a rule of thumb in `SKILL.md`.
2. `docs(skill): note attribute-slot rule in api.md` — documents `Invalid HTML position` and the precompute fix.
3. `docs(skill): close a11y gaps from testing` — APG tabs keyboard handler + imperative-DOM bridge examples; reactive-list callable wrap and event-handler typing bullets in api.md.

Total: ~120 lines across 4 files.

## Divergence from the issue proposal

The original proposal asked for `references/patterns/` with per-widget docs (accordion, tabs, dialog, disclosure, menu). I prototyped that shape (~1,000 lines, 9 files) and decided against it:

- Per-pattern files largely re-author WAI-ARIA APG content, which drifts over time and bloats the skill.
- A principles file + APG link achieves "accessible by default" at <10% of the token cost.
- Arrow-specific value sits in gotchas and native-first reminders, not in reproducing WAI-ARIA.

## Arrow-specific content

**Enumerated ARIA vs `setAttr`.** `packages/core/src/dom.ts:16-18` removes an attribute when an expression returns JS `false`. Correct for boolean HTML attrs, wrong for `aria-expanded` / `aria-pressed` / `aria-selected` / `aria-checked` / `aria-current` where absence ≠ `"false"`. Called out with ✅/❌ examples.

**Native-first reminders.** `<details>`, `<dialog>`, `<input type="checkbox" role="switch">`.

**APG keyboard handler example.** Concrete tabs example showing roving tabindex (strings), Arrow/Home/End keys, and `queueMicrotask` for post-update focus. Closes the gap where "implement the keyboard section" as guidance alone produced partial output.

**Imperative DOM bridge.** Arrow has no ref primitive; the skill now documents `watch()` + `querySelector` as the reactive → imperative pattern. Load-bearing for native `<dialog>`, `<video>`, `<canvas>`, focus management.

**Attribute-slot rule (api.md).** ARIA wiring is almost entirely dynamic id attributes — `aria-controls="panel-${id}"`, `aria-labelledby="header-${id}"`, `id="tab-${key}"`. Arrow's template parser requires attribute expressions to be the entire value; partial interpolation throws `Invalid HTML position`. Accessibility doc tells agents which attributes to use; api.md rule tells them how to build the id strings without crashing.

**Event handler typing (api.md).** `ArrowExpression` (`packages/core/src/html.ts:75`) accepts `EventListener` or `(e: InputEvent) => void`. Narrower signatures like `(e: KeyboardEvent) => void` fail typecheck — documented with the widen + cast fix, essential for APG keyboard handlers.

**Reactive list callable wrap (api.md).** `${() => items.map(...)}` is required for dynamic lists. Every ARIA list (tabs, combobox options, rows) hits this.

## Testing

Generated 5 scenarios (disclosure, dialog, tabs, status, todos) with fresh subagents — once without the skill, once with it injected. Deltas:

| Scenario | Without skill | With skill |
|---|---|---|
| Disclosure | `String(state.open)` works | explicit ternary, works |
| Dialog | `<div role="dialog">`, no focus trap | native `<dialog>` + `showModal()` |
| Tabs | roles only | roles + roving tabindex + `.key()` (still no kbd) |
| Status | redundant `aria-live` | clean `role="status"` |
| Todos | `.key()` + `aria-label` | identical |

The tabs gap (no keyboard handler) and the dialog "no ref primitive" question both surfaced here — addressed by commit 3.

## Validation

Ran a fresh Claude Code session in a new directory with the skill available. Generated implementations of the same 5 scenarios. Every load-bearing claim from this PR shows up in the output: native `<dialog>` with `watch()+getElementById` bridge, APG tabs with Arrow/Home/End + `queueMicrotask` focus, reactive `aria-*` as strings, `EventListener` typing with inline cast, precomputed id strings.

## Test plan

- [x] `pnpm test` — 245 passed
- [ ] Reviewer: sanity-check the single-file shape vs. per-pattern files — happy to add targeted pattern docs (e.g., `references/patterns/combobox.md`) if specific widgets need deeper Arrow-specific coverage